### PR TITLE
simplify config

### DIFF
--- a/notebooks/QuickStart.ipynb
+++ b/notebooks/QuickStart.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "ApertureDB is set up as a database (server) and can be accessed from clients anywhere as long as the server is accessible on the network to the client.\n",
     "\n",
-    "Sign up for an Aperture [cloud account here](https://aperturedata.io/cloud) (30 days free trial) or see [other methods here](http://docs.aperturedata.io/category/setup-server)"
+    "Sign up for an Aperture [cloud account here](https://cloud.aperturedata.io) (30 days free trial) or see [other methods here](http://docs.aperturedata.io/category/setup-server)"
    ]
   },
   {
@@ -74,7 +74,7 @@
    "id": "0692b1ed",
    "metadata": {},
    "source": [
-    "## c) Define server configuration\n",
+    "### c) Define server configuration\n",
     "\n",
     "The easiest way to set up a configuration is to paste a JSON configuration string into `adb config create`.\n",
     "See [Configuration](https://docs.aperturedata.io//Setup/client/configuration) for how to get this string and for alternative ways to set up a configuration."

--- a/notebooks/QuickStart.ipynb
+++ b/notebooks/QuickStart.ipynb
@@ -12,7 +12,7 @@
     "* Setup a Google Colab notebook with aperturedb client\n",
     "* Then configure it\n",
     "* Load a dataset ApertureDB server\n",
-    "* Query!"
+    "* Run Queries!"
    ]
   },
   {
@@ -71,83 +71,31 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b120d0ff-caa9-45c9-a086-5b4f0061b436",
+   "id": "0692b1ed",
    "metadata": {},
    "source": [
-    "### c) Define server configuration\n",
+    "## c) Define server configuration\n",
     "\n",
-    "**On ApertureDB-Cloud**\n",
-    "\n",
-    "When you click on Connect for your instance, you can copy the JSON configuration string for your server. It looks like:\n",
-    "\n",
-    "![cloud](images/connect_on_cloud.png)\n",
-    "![connect](images/connect_json.png)\n",
-    "\n",
-    "```javascript title=\"template only. Use actual values\"\n",
-    "{\n",
-    "  \"host\": \"<hostname>\",\n",
-    "  \"port\": 55555,\n",
-    "  \"username\": \"admin\",\n",
-    "  \"password\": \"[User enters passwd here]\",\n",
-    "  \"name\": \"demo\",\n",
-    "  \"use_ssl\": true,\n",
-    "  \"use_rest\": false,\n",
-    "  \"use_keepalive\": true,\n",
-    "  \"retry_interval_seconds\": 1,\n",
-    "  \"retry_max_attempts\": 3\n",
-    "}\n",
-    "```\n",
-    "\n",
-    "> **Information**\n",
-    ">\n",
-    "> For any other method, the parameters for `host` will depend on where the database is hosted.\n",
-    ">\n",
-    "> Default username:password values are `admin`:`admin`.\n",
-    ">\n",
-    "> Default `port` that ApertureDB listens on is `55555` (on linux) or `55557` (on MacOS)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c4cfb3e2-6419-40b0-8452-563ee0b070cc",
-   "metadata": {},
-   "source": [
-    "### d) For Colab - Add Server Configuration to Secrets\n",
-    "\n",
-    "The easiest way to configure one or more Colab notebooks to point to the same ApertureDB server is to put the JSON config into a Colab secret.\n",
-    "\n",
-    "This secret will persist over runtime restarts and can be used by all of your notebooks, but it will not be exposed if you share your notebook with anyone.\n",
-    "\n",
-    "![Screenshot of setting a Colab Secret](images/colab-secret.png)\n",
-    "\n",
-    "1. Click on the key icon at the left of Google Colab to open the Secrets interface.\n",
-    "2. Click on \"Add new secret\"\n",
-    "3. Ensure that \"Notebook access\" is enabled\n",
-    "4. For the name, enter `APERTUREDB_JSON`\n",
-    "5. Paste the JSON object into the \"Value\" box."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e81dc85c-4171-44ed-b638-c0639182c4c8",
-   "metadata": {},
-   "source": [
-    "### e) For Jupyter lab - Run adb config create\n",
-    "\n",
-    "If there is no active configuration, a new one needs to be created as a one time setup. It's interactive and will ask you for the parameters needed to create a connection.\n",
-    "\n",
-    "It will used for all subsequent ApertureDB connections and the command line utility `adb` has an easy command switch between instances."
+    "The easiest way to set up a configuration is to paste a JSON configuration string into `adb config create`.\n",
+    "See [Configuration](https://docs.aperturedata.io//Setup/client/configuration) for how to get this string and for alternative ways to set up a configuration."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "315c29a9-c0c6-46f2-b1e9-8fb83fa8785a",
+   "execution_count": 4,
+   "id": "3cd0d138",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Enter JSON string: "
+     ]
+    }
+   ],
    "source": [
-    "# Change Port to 55557 for a Mac installation of ApertureDB\n",
-    "! adb config create my_adb_config --host \"localhost\" --port 55555 --username \"admin\" --password \"temp_password\" --no-interactive"
+    "! adb config create notebook --from-json "
    ]
   },
   {


### PR DESCRIPTION
This change relies on https://github.com/aperture-data/aperturedb-python/pull/502 and https://github.com/aperture-data/docs/pull/207

With these changes, the simplest way to configure a connection is now short and simple.