### PR TITLE
drop config name and add active

### DIFF
--- a/notebooks/QuickStart.ipynb
+++ b/notebooks/QuickStart.ipynb
@@ -95,7 +95,7 @@
     }
    ],
    "source": [
-    "! adb config create notebook --from-json "
+    "! adb config create --active --from-json "
    ]
   },
   {


### PR DESCRIPTION
As discussed this morning, drop config name and add `--active`. 

Blocked by https://github.com/aperture-data/aperturedb-python/pull/510