### PR TITLE
Fix broken absolute doc links in notebooks

### DIFF
--- a/notebooks/simple/BulkEmbeddings.ipynb
+++ b/notebooks/simple/BulkEmbeddings.ipynb
@@ -241,7 +241,7 @@
    "source": [
     "## Bulk Ingest with ParallelLoader\n",
     "\n",
-    "[ParallelLoader](https://docs.aperturedata.io/python_sdk/data_loaders/ParallelLoader) ingests data concurrently. It takes any `Subscriptable` \u2014 here we build a simple list of `(query, blobs)` pairs."
+    "[ParallelLoader](https://docs.aperturedata.io/python_sdk/parallel_exec/ParallelLoader) ingests data concurrently. It takes any `Subscriptable` \u2014 here we build a simple list of `(query, blobs)` pairs."
    ]
   },
   {

--- a/notebooks/simple/HybridSearch.ipynb
+++ b/notebooks/simple/HybridSearch.ipynb
@@ -624,7 +624,7 @@
    "source": [
     "## What's Next\n",
     "\n",
-    "- [Hybrid Search page](https://docs.aperturedata.io/HowToGuides/Ingestion/Hybrid_Search): constraint operators reference\n",
+    "- [Hybrid Search page](https://docs.aperturedata.io/HowToGuides/Advanced/Filtering_Aggregation_Facets): constraint operators reference\n",
     "- [Bulk Embeddings](https://docs.aperturedata.io/HowToGuides/start/BulkEmbeddings): ingest large numbers of embeddings with ParallelLoader\n",
     "- [Building RAG Pipelines](https://docs.aperturedata.io/HowToGuides/Ingestion/RAG): use hybrid search as the retrieval step in a RAG chain\n",
     "- [FindDescriptor reference](https://docs.aperturedata.io/query_language/Reference/descriptor_commands/desc_commands/FindDescriptor): full list of parameters\n",

--- a/notebooks/simple/PDF.ipynb
+++ b/notebooks/simple/PDF.ipynb
@@ -517,7 +517,7 @@
     "\n",
     "- [Embeddings Extraction workflow](https://docs.aperturedata.io/workflows/embeddings_extraction): production-scale PDF ingestion with OCR, configurable chunking, and parallel loading\n",
     "- [Work with Blobs](https://docs.aperturedata.io/HowToGuides/start/Blobs): other binary formats (text, audio)\n",
-    "- [Vector Search](https://docs.aperturedata.io/vector-search): full vector search guide with filtering and RAG\n",
+    "- [Vector Search](https://docs.aperturedata.io/HowToGuides/start/VectorSearch): full vector search guide with filtering and RAG\n",
     "- [LangChain Integration](https://docs.aperturedata.io/Integrations/langchain_howto): connect ApertureDB to a LangChain RAG pipeline"
    ]
   }

--- a/notebooks/simple/TextSearch.ipynb
+++ b/notebooks/simple/TextSearch.ipynb
@@ -530,7 +530,7 @@
     "\n",
     "- [Quick Start](https://docs.aperturedata.io/Setup/QuickStart): load the full Cookbook dataset with CLIP image embeddings and graph connections\n",
     "- [Work with Descriptors](https://docs.aperturedata.io/HowToGuides/start/Embeddings): update, delete, and bulk-load embeddings\n",
-    "- [Vector RAG](https://docs.aperturedata.io/vector-search#vector-rag-with-aperturedb): connect ApertureDB to LangChain for question answering\n",
+    "- [Vector RAG](https://docs.aperturedata.io/HowToGuides/start/VectorSearch#vector-rag-with-aperturedb): connect ApertureDB to LangChain for question answering\n",
     "- [ApertureDB Cloud](https://cloud.aperturedata.io): managed instance, free 30-day trial\n"
    ]
   }


### PR DESCRIPTION
- HybridSearch: Ingestion/Hybrid_Search â Advanced/Filtering_Aggregation_Facets
- BulkEmbeddings: python_sdk/data_loaders â python_sdk/parallel_exec
- TextSearch, PDF: /vector-search â /HowToGuides/start/VectorSearch